### PR TITLE
Prevent failing of chef run  in case there is no local domains defined.....

### DIFF
--- a/templates/default/named.conf.local.erb
+++ b/templates/default/named.conf.local.erb
@@ -29,7 +29,7 @@ view "<%= view %>-view" {
 				<% if !node['bind9']['keys'][view].nil? %>
 		allow-transfer { key <%= "#{view}-key" %>;};
 				<% end %>
-				<% if !!node[:bind9][:notify] %>
+				<% if not node[:bind9][:notify].nil? %>
 					<% if !!node[:bind9][:notify][view] %>
 		also-notify {<% node[:bind9][:notify][view].each do |addr| %> <%= addr %>; <% end %> };
 					<% end %>


### PR DESCRIPTION
!!node[:bind9][:nofity] fails in some versions of Chef client, this should be failsafe...
